### PR TITLE
Fix AddChatScreen useLayoutEffect options

### DIFF
--- a/Screens/AddChatScreen.js
+++ b/Screens/AddChatScreen.js
@@ -57,8 +57,8 @@ const AddChatScreen = ({ navigation }) => {
     navigation.setOptions({
       title: "Add a New Chat",
       headerBackTitle: "Chats"
-    }, [navigation])
-  })
+    })
+  }, [navigation])
   return (
     <View>
       <Input


### PR DESCRIPTION
## Summary
- pass `[navigation]` to the useLayoutEffect hook instead of navigation.setOptions
- ensure file ends with a newline

## Testing
- `npm run` (no tests configured)


------
https://chatgpt.com/codex/tasks/task_e_683f41b57c848330aaad7ad0c2c88a69